### PR TITLE
docs: document naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,16 @@ services/
 - Update this file with progress notes and next steps.
 - Ensure work aligns with IEC 62304, ISO 13485 and ISO/IEC 27001.
 
+## Naming Conventions
+| Context            | Convention        | Example                   | Rationale |
+|--------------------|------------------|---------------------------|-----------|
+| Repository folder  | PascalCase       | `VariantEffectService`    | Matches class/module style in codebases (Python/Java). Easier to associate with service responsibility. |
+| Docker image name  | kebab-case       | `variant-effect-service`  | Required for Artifact Registry, Docker, and K8s (lowercase DNS-compliant). |
+| Cloud Run service  | kebab-case       | `variant-effect-service`  | Cloud Run/K8s enforce lowercase + hyphens. |
+| URLs               | kebab-case       | `/variant-effect-service` | Readable and consistent with REST/HTTP norms. |
+
+**Rule:** Always use `VariantEffectService` inside the repo. Always use `variant-effect-service` for deployment artifacts, containers, and URLs.
+
 ## Deployment Approach
 - Build Docker images with Google Cloud Build.
 - Push images to Google Artifact Registry.
@@ -41,9 +51,10 @@ services/
 - Added `VariantEffectService` with FastAPI endpoints, tests, docs, and Dockerfile.
 - Refactored `VariantEffectService` endpoints and tests to async/await for concurrency readiness; updated CI dependencies.
 - Updated repository metadata and CI workflow.
+- Documented naming conventions and developer guidelines.
 
 ## Suggested Next Step
-- Integrate real variant effect model into `VariantEffectService`.
+- Integrate real variant effect model into `VariantEffectService` and enforce naming conventions across new services.
 
 ## Microservice Status
 | Service | Status |

--- a/docs/PROJECT_INSTRUCTIONS.md
+++ b/docs/PROJECT_INSTRUCTIONS.md
@@ -14,5 +14,14 @@ All development must align with:
 - Usability notes (IEC 62366-1).
 - Deploy via Cloud Run + Batch, with logging/monitoring.
 
+## Naming Conventions
+
+- **Inside the repo (folders, docs):** use **PascalCase** (e.g., `VariantEffectService`).
+- **For infrastructure (Docker images, Cloud Run, URLs):** use **kebab-case** (e.g., `variant-effect-service`).
+
+This separation avoids conflicts:
+- PascalCase improves readability in code and matches class/module conventions.
+- kebab-case ensures compatibility with Docker, Kubernetes, and DNS constraints.
+
 ## Note
 All outputs marked **research-only** unless validated.


### PR DESCRIPTION
## Summary
- add naming convention guidelines for repo and deployments
- document naming conventions in developer instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb0df0c388321be750caff0fd4ff9